### PR TITLE
General adjustments

### DIFF
--- a/lib/presentation/buyer/reservation/reservation_widget.dart
+++ b/lib/presentation/buyer/reservation/reservation_widget.dart
@@ -205,9 +205,8 @@ class ReservationWidget extends StatelessWidget {
                           ),
                           const SizedBox(height: 30),
                           Visibility(
-                              visible:
-                                  state.reservation?.status ==
-                                      ReservationStatus.awaitingBuyer,
+                              visible: state.reservation?.status ==
+                                  ReservationStatus.awaitingBuyer,
                               child: ListView(
                                 shrinkWrap: true,
                                 physics: const ClampingScrollPhysics(),
@@ -255,10 +254,10 @@ class ReservationWidget extends StatelessWidget {
                                                     onPressed: () {
                                                       context
                                                           .read<
-                                                          SingleReservationBloc>()
+                                                              SingleReservationBloc>()
                                                           .add(SingleReservationEvent
-                                                          .onCancelPressed(
-                                                          index));
+                                                              .onCancelPressed(
+                                                                  index));
                                                     },
                                                     child: Container(
                                                       padding: const EdgeInsets
@@ -338,31 +337,36 @@ class ReservationWidget extends StatelessWidget {
                                   const SizedBox(height: 40),
                                 ],
                               )),
-                          const Divider(),
-                          if (state.reservation?.status !=
-                                  ReservationStatus.buyerCanceled &&
-                              state.reservation?.status !=
-                                  ReservationStatus.sellerCanceled)
-                            MaterialButton(
-                              onPressed: () {
-                                context.read<SingleReservationBloc>().add(
-                                    const SingleReservationEvent
-                                        .onCancelReservationPressed());
-                              },
-                              child: Container(
-                                padding:
-                                    const EdgeInsets.fromLTRB(50, 10, 50, 10),
-                                decoration: const BoxDecoration(
-                                    color: ColorSet.red1Alpha,
-                                    borderRadius:
-                                        BorderRadius.all(Radius.circular(20))),
-                                child: const Text('Cancelar Pedido',
-                                    textAlign: TextAlign.center,
-                                    style: TextStyle(
-                                        fontWeight: FontWeight.bold,
-                                        color: ColorSet.red1)),
-                              ),
-                            ),
+                          Visibility(
+                              visible: state.reservation?.status ==
+                                      ReservationStatus.awaitingBuyer ||
+                                  state.reservation?.status ==
+                                      ReservationStatus.pendingSeller,
+                              child: Column(
+                                children: [
+                                  const Divider(),
+                                  MaterialButton(
+                                    onPressed: () {
+                                      context.read<SingleReservationBloc>().add(
+                                          const SingleReservationEvent
+                                              .onCancelReservationPressed());
+                                    },
+                                    child: Container(
+                                      padding: const EdgeInsets.fromLTRB(
+                                          50, 10, 50, 10),
+                                      decoration: const BoxDecoration(
+                                          color: ColorSet.red1Alpha,
+                                          borderRadius: BorderRadius.all(
+                                              Radius.circular(20))),
+                                      child: const Text('Cancelar Pedido',
+                                          textAlign: TextAlign.center,
+                                          style: TextStyle(
+                                              fontWeight: FontWeight.bold,
+                                              color: ColorSet.red1)),
+                                    ),
+                                  ),
+                                ],
+                              ))
                         ],
                       ),
                     )),

--- a/lib/presentation/buyer/reservation/reservation_widget.dart
+++ b/lib/presentation/buyer/reservation/reservation_widget.dart
@@ -341,7 +341,9 @@ class ReservationWidget extends StatelessWidget {
                               visible: state.reservation?.status ==
                                       ReservationStatus.awaitingBuyer ||
                                   state.reservation?.status ==
-                                      ReservationStatus.pendingSeller,
+                                      ReservationStatus.pendingSeller ||
+                                  state.reservation?.status ==
+                                      ReservationStatus.confirmed,
                               child: Column(
                                 children: [
                                   const Divider(),
@@ -375,46 +377,44 @@ class ReservationWidget extends StatelessWidget {
                 height: 1,
                 color: ColorSet.gray10,
               ),
-              SizedBox(
-                height: 40,
-                child: Stack(
-                  children: [
-                    InkWell(
-                      onTap: () {
-                        context.read<SingleReservationBloc>().add(
-                            const SingleReservationEvent.onExpandPressed());
-                      },
-                      child: SizedBox(
-                        width: double.infinity,
-                        child: Center(
-                          child: Text(
-                            context
-                                    .read<SingleReservationBloc>()
-                                    .state
-                                    .isItemVisible
-                                ? 'Itens'
-                                : 'Ver itens',
-                            style: const TextStyle(fontWeight: FontWeight.bold),
-                          ),
-                        ),
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(0, 0, 20, 0),
-                      child: Align(
-                        alignment: Alignment.centerRight,
-                        child: Icon(
+              InkWell(
+                onTap: () {
+                  context
+                      .read<SingleReservationBloc>()
+                      .add(const SingleReservationEvent.onExpandPressed());
+                },
+                child: SizedBox(
+                  height: 40,
+                  child: Stack(
+                    children: [
+                      Align(
+                        child: Text(
                           context
                                   .read<SingleReservationBloc>()
                                   .state
                                   .isItemVisible
-                              ? Icons.expand_less
-                              : Icons.expand_more,
-                          size: 32,
+                              ? 'Itens'
+                              : 'Ver itens',
+                          style: const TextStyle(fontWeight: FontWeight.bold),
                         ),
                       ),
-                    )
-                  ],
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(0, 0, 20, 0),
+                        child: Align(
+                          alignment: Alignment.centerRight,
+                          child: Icon(
+                            context
+                                    .read<SingleReservationBloc>()
+                                    .state
+                                    .isItemVisible
+                                ? Icons.expand_less
+                                : Icons.expand_more,
+                            size: 32,
+                          ),
+                        ),
+                      )
+                    ],
+                  ),
                 ),
               ),
             ],

--- a/lib/presentation/profile/profile_page.dart
+++ b/lib/presentation/profile/profile_page.dart
@@ -241,7 +241,8 @@ class ProfilePage extends StatelessWidget {
                                       MainAxisAlignment.spaceEvenly,
                                   children: [
                                     TextButton(
-                                      onPressed: () => Navigator.pop(dialogContext),
+                                      onPressed: () =>
+                                          Navigator.pop(dialogContext),
                                       child: const Text(
                                         'Voltar',
                                         style: TextStyle(
@@ -282,6 +283,36 @@ class ProfilePage extends StatelessWidget {
                     color: ColorSet.grayLine,
                   ),
                   ListTile(
+                    onTap: () {
+                      if (context.read<ProfileBloc>().state.isBuyer) {
+                        context.read<BuyerMenuBloc>().add(
+                              const BuyerMenuEvent.navToSellerTapped(),
+                            );
+                      } else {
+                        context.read<SellerMenuBloc>().add(
+                              const SellerMenuEvent.navToBuyerTapped(),
+                            );
+                      }
+                    },
+                    leading: SvgPicture.asset(
+                      'assets/devices.svg',
+                      width: 24,
+                      height: 24,
+                      color: context.read<ProfileBloc>().state.isBuyer
+                          ? ColorSet.colorPrimaryGreen
+                          : ColorSet.brown1,
+                    ),
+                    title: Text(
+                      context.read<ProfileBloc>().state.isBuyer
+                          ? 'Quero vender no app!'
+                          : 'Quero comprar no app!',
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                      ),
+                    ),
+                  ),
+                  ListTile(
                     leading: SvgPicture.asset(
                       'assets/help.svg',
                       width: 24,
@@ -310,36 +341,6 @@ class ProfilePage extends StatelessWidget {
                     title: const Text(
                       'Termos e Privacidade',
                       style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                        fontSize: 14,
-                      ),
-                    ),
-                  ),
-                  ListTile(
-                    onTap: () {
-                      if (context.read<ProfileBloc>().state.isBuyer) {
-                        context.read<BuyerMenuBloc>().add(
-                              const BuyerMenuEvent.navToSellerTapped(),
-                            );
-                      } else {
-                        context.read<SellerMenuBloc>().add(
-                              const SellerMenuEvent.navToBuyerTapped(),
-                            );
-                      }
-                    },
-                    leading: SvgPicture.asset(
-                      'assets/devices.svg',
-                      width: 24,
-                      height: 24,
-                      color: context.read<ProfileBloc>().state.isBuyer
-                          ? ColorSet.colorPrimaryGreen
-                          : ColorSet.brown1,
-                    ),
-                    title: Text(
-                      context.read<ProfileBloc>().state.isBuyer
-                          ? 'Quero vender no app!'
-                          : 'Quero comprar no app!',
-                      style: const TextStyle(
                         fontWeight: FontWeight.bold,
                         fontSize: 14,
                       ),

--- a/lib/presentation/seller/advertisements/advertisement_widget.dart
+++ b/lib/presentation/seller/advertisements/advertisement_widget.dart
@@ -120,15 +120,15 @@ class AdvertisementWidget extends StatelessWidget {
                                 itemCount: advertisement.products.length,
                               ),
                               const SizedBox(height: 4),
-                              const Text(
-                                'Alterar itens',
-                                style: TextStyle(
-                                  color: ColorSet.colorPrimaryGreen,
-                                  fontSize: 12,
-                                  decoration: TextDecoration.underline,
-                                ),
-                              ),
-                              const SizedBox(height: 30),
+                              // const Text(
+                              //   'Alterar itens',
+                              //   style: TextStyle(
+                              //     color: ColorSet.colorPrimaryGreen,
+                              //     fontSize: 12,
+                              //     decoration: TextDecoration.underline,
+                              //   ),
+                              // ),
+                              // const SizedBox(height: 30),
                               // MaterialButton(
                               //   onPressed: () {
                               //     context.read<SingleAdvertisementBloc>().add(
@@ -204,14 +204,12 @@ class AdvertisementWidget extends StatelessWidget {
                                                 MainAxisAlignment.spaceEvenly,
                                             children: [
                                               TextButton(
-                                                onPressed: () =>
-                                                    Navigator.pop(
-                                                        dialogContext),
+                                                onPressed: () => Navigator.pop(
+                                                    dialogContext),
                                                 child: const Text(
                                                   'Voltar',
                                                   style: TextStyle(
-                                                    fontWeight:
-                                                        FontWeight.bold,
+                                                    fontWeight: FontWeight.bold,
                                                     color: ColorSet.grayDark,
                                                   ),
                                                 ),

--- a/lib/presentation/seller/reservation/seller_reservation_widget.dart
+++ b/lib/presentation/seller/reservation/seller_reservation_widget.dart
@@ -148,44 +148,56 @@ class SellerReservationWidget extends StatelessWidget {
                               const SizedBox(
                                 height: 4,
                               ),
-                              GestureDetector(
-                                  onTap: () {
-                                    context.read<SellerMenuBloc>().add(
-                                        SellerMenuEvent.reservationEditItemsTap(
-                                            state.reservation));
-                                  },
-                                  child: const Text('Alterar itens',
-                                      style: TextStyle(
-                                          color: ColorSet.brown1,
-                                          fontSize: 12,
-                                          decoration:
-                                              TextDecoration.underline))),
-                              const SizedBox(height: 20),
-                              if (state.reservation?.status ==
-                                      ReservationStatus.awaitingBuyer ||
-                                  state.reservation?.status ==
-                                      ReservationStatus.pendingSeller)
-                                MaterialButton(
-                                  onPressed: () {
-                                    context.read<SellerReservationBloc>().add(
-                                        const SellerReservationEvent
-                                            .onCancel());
-                                  },
-                                  child: Container(
-                                    width: double.infinity,
-                                    padding: const EdgeInsets.fromLTRB(
-                                        50, 10, 50, 10),
-                                    decoration: const BoxDecoration(
-                                        color: ColorSet.red1,
-                                        borderRadius: BorderRadius.all(
-                                            Radius.circular(20))),
-                                    child: const Text('Cancelar Pedido',
-                                        textAlign: TextAlign.center,
-                                        style: TextStyle(
-                                            fontWeight: FontWeight.bold,
-                                            color: Colors.white)),
-                                  ),
-                                ),
+                              Visibility(
+                                  visible: state.reservation?.status ==
+                                          ReservationStatus.awaitingBuyer ||
+                                      state.reservation?.status ==
+                                          ReservationStatus.pendingSeller ||
+                                      state.reservation?.status ==
+                                          ReservationStatus.confirmed,
+                                  child: Column(
+                                    children: [
+                                      Align(
+                                          alignment: Alignment.centerLeft,
+                                          child: GestureDetector(
+                                              onTap: () {
+                                                context
+                                                    .read<SellerMenuBloc>()
+                                                    .add(SellerMenuEvent
+                                                        .reservationEditItemsTap(
+                                                            state.reservation));
+                                              },
+                                              child: const Text('Alterar itens',
+                                                  style: TextStyle(
+                                                      color: ColorSet.brown1,
+                                                      fontSize: 12,
+                                                      decoration: TextDecoration
+                                                          .underline)))),
+                                      const SizedBox(height: 20),
+                                      MaterialButton(
+                                        onPressed: () {
+                                          context
+                                              .read<SellerReservationBloc>()
+                                              .add(const SellerReservationEvent
+                                                  .onCancel());
+                                        },
+                                        child: Container(
+                                          width: double.infinity,
+                                          padding: const EdgeInsets.fromLTRB(
+                                              50, 10, 50, 10),
+                                          decoration: const BoxDecoration(
+                                              color: ColorSet.red1,
+                                              borderRadius: BorderRadius.all(
+                                                  Radius.circular(20))),
+                                          child: const Text('Cancelar Pedido',
+                                              textAlign: TextAlign.center,
+                                              style: TextStyle(
+                                                  fontWeight: FontWeight.bold,
+                                                  color: Colors.white)),
+                                        ),
+                                      ),
+                                    ],
+                                  )),
                               if (state.reservation?.status ==
                                   ReservationStatus.pendingSeller)
                                 MaterialButton(

--- a/lib/presentation/seller/reservation/seller_reservation_widget.dart
+++ b/lib/presentation/seller/reservation/seller_reservation_widget.dart
@@ -161,10 +161,10 @@ class SellerReservationWidget extends StatelessWidget {
                                           decoration:
                                               TextDecoration.underline))),
                               const SizedBox(height: 20),
-                              if (state.reservation?.status !=
-                                      ReservationStatus.buyerCanceled &&
-                                  state.reservation?.status !=
-                                      ReservationStatus.sellerCanceled)
+                              if (state.reservation?.status ==
+                                      ReservationStatus.awaitingBuyer ||
+                                  state.reservation?.status ==
+                                      ReservationStatus.pendingSeller)
                                 MaterialButton(
                                   onPressed: () {
                                     context.read<SellerReservationBloc>().add(


### PR DESCRIPTION
- Hide "Cancelar pedido" if reservation is not pending or confirmed
- Move the role switch ("Quero vender/comprar no app") to the top of Help
- Hide "Alterar itens" if reservation is not pending or confirmed (seller)
- Hide "Alterar itens" for advertisement widget (does nothing)
- Fix tap on "Ver itens" for buyer (was not expanding/collapsing when tapped on the icon)